### PR TITLE
Set floating package version

### DIFF
--- a/src/Hangfire.Correlate/Hangfire.Correlate.csproj
+++ b/src/Hangfire.Correlate/Hangfire.Correlate.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Correlate" Version="3.0.0" />
-    <PackageReference Include="Hangfire" Version="1.7.0" />
+    <PackageReference Include="Hangfire" Version="1.7.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The hangfire reference could use a floating reference for the last digit to avoid having to downgrade the hangfire package for minor changes.
