### PR TITLE
fix: refactor getting job parameter out of connection that gets disposed

### DIFF
--- a/src/Hangfire.Correlate/CorrelateFilterAttribute.cs
+++ b/src/Hangfire.Correlate/CorrelateFilterAttribute.cs
@@ -47,8 +47,7 @@ namespace Hangfire.Correlate
 				return null;
 			}
 
-			IStorageConnection conn = filterContext.Storage.GetConnection();
-			string parentCorrelationId = SerializationHelper.Deserialize<string>(conn.GetJobParameter(awaitingState.ParentId, CorrelationIdKey));
+			string parentCorrelationId = SerializationHelper.Deserialize<string>(filterContext.Connection.GetJobParameter(awaitingState.ParentId, CorrelationIdKey));
 
 			return !string.IsNullOrEmpty(parentCorrelationId)
 				? parentCorrelationId


### PR DESCRIPTION
 refactor getting job parameter out of filter attribute with a connection that automatically will be disposed and fixes not disposed connections now.