### PR TITLE
test: fix some times happening race condition 'Collection was modified; enumeration operation may not execute.

### DIFF
--- a/test/Hangfire.Correlate.Tests/HangfireIntegrationTests.cs
+++ b/test/Hangfire.Correlate.Tests/HangfireIntegrationTests.cs
@@ -71,13 +71,14 @@ public abstract class HangfireIntegrationTests : GlobalTestContext
         IMonitoringApi monitoringApi = JobStorage.Current.GetMonitoringApi();
 
         var sw = Stopwatch.StartNew();
-        JobDetailsDto? jobDetails = null;
+        StateHistoryDto[] jobHistory = Array.Empty<StateHistoryDto>();
         while (
-            (jobDetails is null || jobDetails.History.All(s => s.StateName != "Succeeded"))
+            (jobHistory.All(s => s.StateName != "Succeeded"))
          && (sw.Elapsed.TotalMilliseconds < maxWaitInMilliseconds || Debugger.IsAttached))
         {
             await Task.Delay(25);
-            jobDetails = monitoringApi.JobDetails(jobId);
+            JobDetailsDto jobDetails = monitoringApi.JobDetails(jobId);
+            jobHistory = jobDetails.History.ToArray();
             if (monitoringApi.FailedCount() > 0)
             {
                 break;


### PR DESCRIPTION
From [job log](https://github.com/skwasjer/Hangfire.Correlate/actions/runs/6057413152/job/16438544573):

```
System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
  Stack Trace:
     at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
   at System.Linq.Enumerable.All[TSource](IEnumerable`1 source, Func`2 predicate)
   at Hangfire.Correlate.HangfireIntegrationTests.WaitUntilJobCompletedAsync(String jobId, Int32 maxWaitInMilliseconds) in /Users/runner/work/Hangfire.Correlate/Hangfire.Correlate/test/Hangfire.Correlate.Tests/HangfireIntegrationTests.cs:line 75
   at Hangfire.Correlate.HangfireIntegrationTests.Given_job_is_queued_outside_correlationContext_should_use_jobId_as_correlationId() in /Users/runner/work/Hangfire.Correlate/Hangfire.Correlate/test/Hangfire.Correlate.Tests/HangfireIntegrationTests.cs:line 189
```