### PR TITLE
chore: mark configuration extension accepting `ILoggerFactory` obsolete.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,22 +44,9 @@ A continuation job will inherit the correlation id from the parent job, unless e
 
 Configure Hangfire to use Correlate.
 
-### Using built-in configuration extensions ###
-
-Use the Hangfire built-in configuration extensions to enable Correlate.
-
-```csharp
-ILoggerFactory loggerFactory = new LoggerFactory();
-loggerFactory.AddConsole();
-
-GlobalConfiguration.Configuration
-    .UseCorrelate(loggerFactory)
-    .(...);
-```
-
 ### Using a `IServiceProvider`
 
-Alternatively (but recommended), use `IServiceProvider` to configure Hangfire with Correlate.
+Use the configuration extension with `IServiceProvider` to configure Hangfire with Correlate.
 
 Add package dependencies:
 - [Correlate.DependencyInjection](https://github.com/skwasjer/Correlate)
@@ -72,6 +59,21 @@ services
         .UseCorrelate(serviceProvider)
         .(...)
     );
+```
+
+### Using built-in configuration extensions ###
+
+Use the Hangfire built-in configuration extensions to enable Correlate.
+
+> This is no longer the recommended approach and will most likely be removed in a future version.
+
+```csharp
+ILoggerFactory loggerFactory = new LoggerFactory();
+loggerFactory.AddConsole();
+
+GlobalConfiguration.Configuration
+    .UseCorrelate(loggerFactory)
+    .(...);
 ```
 
 ## Enqueue jobs

--- a/src/Hangfire.Correlate/GlobalConfigurationExtensions.cs
+++ b/src/Hangfire.Correlate/GlobalConfigurationExtensions.cs
@@ -32,7 +32,10 @@ public static class GlobalConfigurationExtensions
         }
         catch (InvalidOperationException ex)
         {
-            throw new InvalidOperationException("Failed to register Correlate with Hangfire. Please ensure `.AddCorrelate()` is called on the service collection.", ex);
+            throw new InvalidOperationException(
+                "Failed to register Correlate with Hangfire. Please ensure `.AddCorrelate()` is called on the service collection.",
+                ex
+            );
         }
     }
 
@@ -41,6 +44,7 @@ public static class GlobalConfigurationExtensions
     /// </summary>
     /// <param name="configuration">The global configuration.</param>
     /// <param name="loggerFactory">The logger factory.</param>
+    [Obsolete("Use the overload accepting an IServiceProvider.")]
     public static IGlobalConfiguration UseCorrelate(this IGlobalConfiguration configuration, ILoggerFactory loggerFactory)
     {
         if (configuration is null)

--- a/src/Hangfire.Correlate/README.md
+++ b/src/Hangfire.Correlate/README.md
@@ -4,22 +4,9 @@
 
 Configure Hangfire to use Correlate.
 
-### Using built-in configuration extensions ###
-
-Use the Hangfire built-in configuration extensions to enable Correlate.
-
-```csharp
-ILoggerFactory loggerFactory = new LoggerFactory();
-loggerFactory.AddConsole();
-
-GlobalConfiguration.Configuration
-    .UseCorrelate(loggerFactory)
-    .(...);
-```
-
 ### Using a `IServiceProvider`
 
-Alternatively (but recommended), use `IServiceProvider` to configure Hangfire with Correlate.
+Use the configuration extension with `IServiceProvider` to configure Hangfire with Correlate.
 
 Add package dependencies:
 - [Correlate.DependencyInjection](https://github.com/skwasjer/Correlate)
@@ -32,6 +19,21 @@ services
         .UseCorrelate(serviceProvider)
         .(...)
     );
+```
+
+### Using built-in configuration extensions ###
+
+Use the Hangfire built-in configuration extensions to enable Correlate.
+
+> This is no longer the recommended approach and will most likely be removed in a future version.
+
+```csharp
+ILoggerFactory loggerFactory = new LoggerFactory();
+loggerFactory.AddConsole();
+
+GlobalConfiguration.Configuration
+    .UseCorrelate(loggerFactory)
+    .(...);
 ```
 
 ## Enqueue jobs


### PR DESCRIPTION
The configuration extension accepting `IServiceProvider` should be preferred.