### PR TITLE
chore: bump xunit and xunit.runner.visualstudio to latest

### DIFF
--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -16,12 +16,12 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)'=='true'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Hangfire.Correlate.Tests/HangfireBuiltInConfigurationTests.cs
+++ b/test/Hangfire.Correlate.Tests/HangfireBuiltInConfigurationTests.cs
@@ -1,5 +1,6 @@
 ﻿using Correlate;
 using Correlate.Http;
+using Hangfire.Logging;
 using Hangfire.Server;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -27,6 +28,7 @@ public class HangfireBuiltInConfigurationTests : HangfireIntegrationTests
 
         GlobalConfiguration.Configuration
             .UseCorrelate(_loggerFactory)
+            .UseLogProvider(Substitute.For<ILogProvider>())
             .UseActivator(
                 new BackgroundTestExecutorJobActivator(
                     () =>

--- a/test/Hangfire.Correlate.Tests/HangfireServiceProviderTests.cs
+++ b/test/Hangfire.Correlate.Tests/HangfireServiceProviderTests.cs
@@ -1,4 +1,5 @@
 ﻿using Correlate.DependencyInjection;
+using Hangfire.Logging;
 using Hangfire.Server;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
@@ -29,6 +30,7 @@ public class HangfireServiceProviderTests : HangfireIntegrationTests
                 {
                     config
                         .UseCorrelate(s)
+                        .UseLogProvider(Substitute.For<ILogProvider>())
                         .UseInMemoryStorage();
                 }
             );


### PR DESCRIPTION
Bumps both xunit dependencies.

Also added noop logger provider to avoid disposal exception after this version bump (weird).

Presumably, some test fixture disposal logic has changed. Since Hangfire relies on a static singleton configuration object, it may be using the wrong reference. Not much we can do but circumvent it by not allowing Hangfire to use our `LoggerFactory` instance.

```
C:\projects\hangfire-525\src\Hangfire.NetCore\AspNetCore\AspNetCoreLogProvider.cs(35): error TESTERROR:
      Hangfire.Correlate.HangfireBuiltInConfigurationTests.Given_job_is_queued_inside_correlationContext_should_use_correlationId_of_correlation_context (1ms): Error Message: System.ObjectDisposedException : Cannot access a disposed object.
      Object name: 'LoggerFactory'.
      Stack Trace:
         at Microsoft.Extensions.Logging.LoggerFactory.CreateLogger(String categoryName)
         at Hangfire.AspNetCore.AspNetCoreLogProvider.GetLogger(String name) in C:\projects\hangfire-525\src\Hangfire.NetCore\AspNetCore\AspNetCoreLogProvider.cs:line 35
         at Hangfire.Logging.LogProvider.GetLogger(String name) in C:\projects\hangfire-525\src\Hangfire.Core\App_Packages\LibLog.1.4\LibLog.cs:line 373
         at Hangfire.Logging.LogProvider.GetLogger(Type type) in C:\projects\hangfire-525\src\Hangfire.Core\App_Packages\LibLog.1.4\LibLog.cs:line 362
         at Hangfire.Logging.LogProvider.For[T]() in C:\projects\hangfire-525\src\Hangfire.Core\App_Packages\LibLog.1.4\LibLog.cs:line 340
         at Hangfire.BackgroundJobServer..ctor(BackgroundJobServerOptions options, JobStorage storage, IEnumerable`1 additionalProcesses, IJobFilterProvider filterProvider, JobActivator activator, IBackgroundJobFactory factory, IBackgroundJobPerformer performer, IBackgroundJobStateChanger stateChanger)
       in C:\projects\hangfire-525\src\Hangfire.Core\BackgroundJobServer.cs:line 33
         at Hangfire.BackgroundJobServer..ctor(BackgroundJobServerOptions options, JobStorage storage, IEnumerable`1 additionalProcesses) in C:\projects\hangfire-525\src\Hangfire.Core\BackgroundJobServer.cs:line 83
         at Hangfire.BackgroundJobServer..ctor(BackgroundJobServerOptions options, JobStorage storage) in C:\projects\hangfire-525\src\Hangfire.Core\BackgroundJobServer.cs:line 74
         at Hangfire.BackgroundJobServer..ctor(BackgroundJobServerOptions options) in C:\projects\hangfire-525\src\Hangfire.Core\BackgroundJobServer.cs:line 63
         at Hangfire.BackgroundJobServer..ctor() in C:\projects\hangfire-525\src\Hangfire.Core\BackgroundJobServer.cs:line 43
         at Hangfire.Correlate.HangfireBuiltInConfigurationTests.CreateServer() in E:\Dev\Correlate\Hangfire.Correlate\test\Hangfire.Correlate.Tests\HangfireBuiltInConfigurationTests.cs:line 72
         at Hangfire.Correlate.HangfireIntegrationTests.InitializeAsync() in E:\Dev\Correlate\Hangfire.Correlate\test\Hangfire.Correlate.Tests\HangfireIntegrationTests.cs:line 47
        Standard Output Messages:
       HangfireBuiltInConfigurationTests,638954892664482897
```