### PR TITLE
revert: bump Correlate from 5.3.0 to 6.0.0

### DIFF
--- a/src/Hangfire.Correlate/Hangfire.Correlate.csproj
+++ b/src/Hangfire.Correlate/Hangfire.Correlate.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Correlate" Version="6.0.0" />
+    <PackageReference Include="Correlate" Version="5.3.0" />
     <PackageReference Include="Hangfire.Core" Version="1.7.37" />
   </ItemGroup>
 


### PR DESCRIPTION
The breaking changes in Correlate are only behaviorally, API/interface wise we can keep referencing the older version, allowing consumers to choose their own upgrade path (and considering the changes of Correlate v6 themselves) instead of us forcing this upon them. At least for now.

This reverts commit a7345c2e95ef49eb1cb0a0c201e30bee4ad53ea8 in #69.